### PR TITLE
EASY-1670 Command-line startup script: argumenten met spaties

### DIFF
--- a/src/main/assembly/dist/bin/easy-manage-curation-work
+++ b/src/main/assembly/dist/bin/easy-manage-curation-work
@@ -18,4 +18,4 @@ fi
 LC_ALL=en_US.UTF-8 \
 java -Dlogback.configurationFile=$LOGBACK_CFG \
      -Dapp.home=$APPHOME \
-     -jar $APPHOME/bin/$MODULE.jar $@
+     -jar $APPHOME/bin/$MODULE.jar "$@"


### PR DESCRIPTION
Fixes EASY-1670 Command-line startup script: argumenten met spaties

**Note: this change has to be done in all EASY modules.  But first this reviewed!**

#### When applied
* it is possible to pass parameters that contain spaces

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
Try parameters with spaces, with different combinations of subcommands and options. 

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
